### PR TITLE
Change the dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates every week
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
- AWS sdk has a new version almost every day! changing the dependabot to weekly as we don't need to be in the latest all the time.
- We don't have an automated CI/CD yet, when it is available, we may need to change this change back to get the update faster.